### PR TITLE
Test for value equality rather than identity.

### DIFF
--- a/pyprt/pyprt_arcgis/pyprt_arcgis.py
+++ b/pyprt/pyprt_arcgis/pyprt_arcgis.py
@@ -41,7 +41,7 @@ def arcgis_to_pyprt(feature_set):
     for feature in feature_set.features:
         try:
             geo = Geometry(feature.geometry)
-            if geo.type is 'Polygon':
+            if geo.type == 'Polygon':
                 coord = geo.coordinates()[0]
                 coord_remove_last = coord[:-1]
                 coord_inverse = np.flip(coord_remove_last, axis=0)


### PR DESCRIPTION
Just a tiny thing I noticed when reviewing @mistafunk 's PR. The string comparison in `pyprt_arcgis.py` should probably be done using `==` (equality) rather than `is` (identity). `is` might still work most of the times because of string interning etc., yet the intention probably is to test if the two strings have the same value.   