### PR TITLE
version: rc suffix must not have a dot

### DIFF
--- a/pyprt/__init__.py
+++ b/pyprt/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 # A copy of the license is available in the repository's LICENSE file.
 
-__version__ = '1.1.0.rc1'
+__version__ = '1.1.0rc1'
 
 from .pyprt import *

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ except:
 pyprt_name = 'PyPRT'
 pyprt_author = 'Esri R&D Center Zurich'
 pyprt_copyright = '(c) 2020, ' + pyprt_author
-pyprt_version = '1.1.0.rc1'  # keep consistent with __version__ in pyprt/__init__.py
+pyprt_version = '1.1.0rc1'  # keep consistent with __version__ in pyprt/__init__.py
 
 record_file = os.path.join(os.path.realpath(os.curdir), pyprt_name+'.egg-info', 'record_setup_develop_files.txt')
 


### PR DESCRIPTION
see https://packaging.python.org/guides/distributing-packages-using-setuptools/#choosing-a-versioning-scheme