### PR TITLE
Add annotations info to "inspect_rpk" function

### DIFF
--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -74,12 +74,12 @@ py::dict getRuleAttributes(const prt::RuleFileInfo* ruleFileInfo) {
 		const std::wstring name = fullName.substr(8);
 
 		for (size_t f = 0; f < attr->getNumAnnotations(); f++) {
-			if (!(std::wcscmp(attr->getAnnotation(f)->getName(), ANNOT_HIDDEN))) {
+			if (std::wcscmp(attr->getAnnotation(f)->getName(), ANNOT_HIDDEN) == 0) {
 				hidden = true;
 				break;
 			}
 
-			if (!(std::wcsncmp(attr->getAnnotation(f)->getName(), L"@", 1))) {
+			if (std::wcsncmp(attr->getAnnotation(f)->getName(), L"@", 1) == 0) {
 				std::vector<py::object> annotation;
 				annotation.push_back(py::cast(attr->getAnnotation(f)->getName())); //first reserve?
 

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -138,7 +138,7 @@ py::dict getRuleAttributes(const prt::RuleFileInfo* ruleFileInfo) {
 	return ruleAttrs;
 }
 
-py::dict inspectRPK(const std::filesystem::path& rulePackagePath) {
+py::dict getRPKInfo(const std::filesystem::path& rulePackagePath) {
 	ResolveMapPtr resolveMap;
 
 	if (!std::filesystem::exists(rulePackagePath) || !pcu::getResolveMap(rulePackagePath, &resolveMap)) {
@@ -178,7 +178,7 @@ PYBIND11_MODULE(pyprt, m) {
 	m.def("initialize_prt", &initializePRT, doc::Init);
 	m.def("is_prt_initialized", &isPRTInitialized, doc::IsInit);
 	m.def("shutdown_prt", &shutdownPRT, doc::Shutdown);
-	m.def("inspect_rpk", &inspectRPK, py::arg("rulePackagePath"), doc::InspectRPK);
+	m.def("get_rpk_attributes_info", &getRPKInfo, py::arg("rulePackagePath"), doc::InspectRPK);
 
 	py::class_<InitialShape>(m, "InitialShape", doc::Is)
 	        .def(py::init<const Coordinates&>(), py::arg("vertCoordinates"), doc::IsInitV)

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -259,8 +259,8 @@ PYBIND11_MODULE(pyprt, m) {
 	m.def("initialize_prt", &initializePRT, doc::Init);
 	m.def("is_prt_initialized", &isPRTInitialized, doc::IsInit);
 	m.def("shutdown_prt", &shutdownPRT, doc::Shutdown);
-	m.def("inspect_rpk", &inspectRPKDeprecated, py::arg("rulePackagePath"), doc::InspectRPK);
-	m.def("get_rpk_attributes_info", &getRPKInfo, py::arg("rulePackagePath"), doc::InspectRPK);
+	m.def("inspect_rpk", &inspectRPKDeprecated, py::arg("rulePackagePath"), doc::InspectRPKDeprecated);
+	m.def("get_rpk_attributes_info", &getRPKInfo, py::arg("rulePackagePath"), doc::GetRPKInfo);
 
 	py::class_<InitialShape>(m, "InitialShape", doc::Is)
 	        .def(py::init<const Coordinates&>(), py::arg("vertCoordinates"), doc::IsInitV)

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -92,7 +92,7 @@ void getAnnotations(const prt::RuleFileInfo::Entry* attribute, std::vector<std::
 
 				py::list annotationParameters;
 				if (std::wcscmp(annotationArg->getKey(), NO_KEY) == 0)
-					annotationParameters.append(py::cast(NO_KEY_PY));
+					annotationParameters.append(py::cast(NO_KEY));
 				else
 					annotationParameters.append(py::cast(annotationArg->getKey()));
 				annotationParameters.append(annotationValue);
@@ -247,6 +247,7 @@ PYBIND11_MODULE(pyprt, m) {
 	m.def("shutdown_prt", &shutdownPRT, doc::Shutdown);
 	m.def("inspect_rpk", &inspectRPKDeprecated, py::arg("rulePackagePath"), doc::InspectRPKDeprecated);
 	m.def("get_rpk_attributes_info", &getRPKInfo, py::arg("rulePackagePath"), doc::GetRPKInfo);
+	m.attr("NO_KEY") = NO_KEY;
 
 	py::class_<InitialShape>(m, "InitialShape", doc::Is)
 	        .def(py::init<const Coordinates&>(), py::arg("vertCoordinates"), doc::IsInitV)

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -104,6 +104,25 @@ void getAnnotations(const prt::RuleFileInfo::Entry* attribute, std::vector<std::
 	}
 }
 
+py::str getAnnotationArgumentTypeString(const prt::AnnotationArgumentType& valueType) {
+	py::str type;
+	if (valueType == prt::AAT_STR)
+		type = "string";
+	else if (valueType == prt::AAT_BOOL)
+		type = "bool";
+	else if (valueType == prt::AAT_FLOAT)
+		type = "float";
+	else if (valueType == prt::AAT_STR_ARRAY)
+		type = "string[]";
+	else if (valueType == prt::AAT_BOOL_ARRAY)
+		type = "bool[]";
+	else if (valueType == prt::AAT_FLOAT_ARRAY)
+		type = "float[]";
+	else
+		type = "UNKNOWN_VALUE_TYPE";
+	return type;
+}
+
 py::dict getRuleAttributes(const prt::RuleFileInfo* ruleFileInfo) {
 	auto ruleAttrs = py::dict();
 
@@ -119,26 +138,9 @@ py::dict getRuleAttributes(const prt::RuleFileInfo* ruleFileInfo) {
 
 		const prt::AnnotationArgumentType valueType = attr->getReturnType();
 		auto dictAttr = py::dict();
-		py::str type;
 		if (!hidden) {
-			if (valueType == prt::AAT_STR)
-				type = "string";
-			else if (valueType == prt::AAT_BOOL)
-				type = "bool";
-			else if (valueType == prt::AAT_FLOAT)
-				type = "float";
-			else if (valueType == prt::AAT_STR_ARRAY)
-				type = "string[]";
-			else if (valueType == prt::AAT_BOOL_ARRAY)
-				type = "bool[]";
-			else if (valueType == prt::AAT_FLOAT_ARRAY)
-				type = "float[]";
-			else
-				type = "UNKNOWN_VALUE_TYPE";
-
-			dictAttr[py::cast("type")] = type;
+			dictAttr[py::cast("type")] = getAnnotationArgumentTypeString(valueType);
 			dictAttr[py::cast("annotations")] = annotations;
-
 			ruleAttrs[py::cast(name)] = dictAttr;
 		}
 	}
@@ -186,7 +188,6 @@ py::dict getRuleAttributesDeprecated(const prt::RuleFileInfo* ruleFileInfo) {
 			continue;
 		const std::wstring name = fullName.substr(8);
 		const prt::AnnotationArgumentType valueType = attr->getReturnType();
-		py::str type;
 
 		for (size_t f = 0; f < attr->getNumAnnotations(); f++) {
 			if (!(std::wcscmp(attr->getAnnotation(f)->getName(), ANNOT_HIDDEN))) {
@@ -196,22 +197,7 @@ py::dict getRuleAttributesDeprecated(const prt::RuleFileInfo* ruleFileInfo) {
 		}
 
 		if (!hidden) {
-			if (valueType == prt::AAT_STR)
-				type = "string";
-			else if (valueType == prt::AAT_BOOL)
-				type = "bool";
-			else if (valueType == prt::AAT_FLOAT)
-				type = "float";
-			else if (valueType == prt::AAT_STR_ARRAY)
-				type = "string[]";
-			else if (valueType == prt::AAT_BOOL_ARRAY)
-				type = "bool[]";
-			else if (valueType == prt::AAT_FLOAT_ARRAY)
-				type = "float[]";
-			else
-				type = "UNKNOWN_VALUE_TYPE";
-
-			ruleAttrs[py::cast(name)] = type;
+			ruleAttrs[py::cast(name)] = getAnnotationArgumentTypeString(valueType);;
 		}
 	}
 

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -65,17 +65,13 @@ py::dict getRuleAttributes(const prt::RuleFileInfo* ruleFileInfo) {
 	auto ruleAttrs = py::dict();
 
 	for (size_t i = 0; i < ruleFileInfo->getNumAttributes(); i++) {
-		auto dictAttr = py::dict();
-		py::str type;
-		std::vector<std::vector<py::object>> annotations;
-		bool hidden = false;
 		const prt::RuleFileInfo::Entry* attr = ruleFileInfo->getAttribute(i);
-
+		bool hidden = false;
+		std::vector<std::vector<py::object>> annotations;
 		const std::wstring fullName(attr->getName());
 		if (fullName.find(L"Default$") != 0)
 			continue;
 		const std::wstring name = fullName.substr(8);
-		const prt::AnnotationArgumentType valueType = attr->getReturnType();
 
 		for (size_t f = 0; f < attr->getNumAnnotations(); f++) {
 			if (!(std::wcscmp(attr->getAnnotation(f)->getName(), ANNOT_HIDDEN))) {
@@ -88,7 +84,6 @@ py::dict getRuleAttributes(const prt::RuleFileInfo* ruleFileInfo) {
 				annotation.push_back(py::cast(attr->getAnnotation(f)->getName())); //first reserve?
 
 				for (size_t u = 0; u < attr->getAnnotation(f)->getNumArguments(); u++) {
-					py::list annotationParameters;
 					py::object annotationValue;
 					const prt::AnnotationArgumentType annotationValueType =
 					        attr->getAnnotation(f)->getArgument(u)->getType();
@@ -102,6 +97,7 @@ py::dict getRuleAttributes(const prt::RuleFileInfo* ruleFileInfo) {
 					else
 						annotationValue = py::cast("UNKNOWN_PARAMETER_VALUE_TYPE");
 
+					py::list annotationParameters;
 					annotationParameters.append(py::cast(attr->getAnnotation(f)->getArgument(u)->getKey()));
 					annotationParameters.append(annotationValue);
 					annotation.push_back(annotationParameters);
@@ -112,6 +108,9 @@ py::dict getRuleAttributes(const prt::RuleFileInfo* ruleFileInfo) {
 
 		}
 
+		const prt::AnnotationArgumentType valueType = attr->getReturnType();
+		auto dictAttr = py::dict();
+		py::str type;
 		if (!hidden) {
 			if (valueType == prt::AAT_STR)
 				type = "string";

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -46,6 +46,8 @@ namespace py = pybind11;
 namespace {
 
 constexpr const wchar_t* ANNOT_HIDDEN = L"@Hidden";
+constexpr const wchar_t* NO_KEY = L"#NULL#";
+constexpr const wchar_t* NO_KEY_PY = L"NO_KEY";
 
 void initializePRT() {
 	auto prt = PRTContext::get(); // this will implicitly construct PRTContext and call prt::init
@@ -89,7 +91,10 @@ void getAnnotations(const prt::RuleFileInfo::Entry* attribute, std::vector<std::
 					annotationValue = py::cast("UNKNOWN_PARAMETER_VALUE_TYPE");
 
 				py::list annotationParameters;
-				annotationParameters.append(py::cast(annotationArg->getKey()));
+				if (std::wcscmp(annotationArg->getKey(), NO_KEY) == 0)
+					annotationParameters.append(py::cast(NO_KEY_PY));
+				else
+					annotationParameters.append(py::cast(annotationArg->getKey()));
 				annotationParameters.append(annotationValue);
 				annotationPyList.push_back(annotationParameters);
 			}

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -74,31 +74,32 @@ py::dict getRuleAttributes(const prt::RuleFileInfo* ruleFileInfo) {
 		const std::wstring name = fullName.substr(8);
 
 		for (size_t f = 0; f < attr->getNumAnnotations(); f++) {
-			if (std::wcscmp(attr->getAnnotation(f)->getName(), ANNOT_HIDDEN) == 0) {
+			const prt::Annotation* annot = attr->getAnnotation(f);
+			if (std::wcscmp(annot->getName(), ANNOT_HIDDEN) == 0) {
 				hidden = true;
 				break;
 			}
 
-			if (std::wcsncmp(attr->getAnnotation(f)->getName(), L"@", 1) == 0) {
+			if (std::wcsncmp(annot->getName(), L"@", 1) == 0) {
 				std::vector<py::object> annotation;
-				annotation.push_back(py::cast(attr->getAnnotation(f)->getName())); //first reserve?
+				annotation.push_back(py::cast(annot->getName())); //first reserve?
 
-				for (size_t u = 0; u < attr->getAnnotation(f)->getNumArguments(); u++) {
+				for (size_t u = 0; u < annot->getNumArguments(); u++) {
 					py::object annotationValue;
-					const prt::AnnotationArgumentType annotationValueType =
-					        attr->getAnnotation(f)->getArgument(u)->getType();
+					const prt::AnnotationArgument* annotationArg = annot->getArgument(u);
+					const prt::AnnotationArgumentType annotationValueType = annotationArg->getType();
 
 					if (annotationValueType == prt::AAT_STR)
-						annotationValue = py::cast(attr->getAnnotation(f)->getArgument(u)->getStr());
+						annotationValue = py::cast(annotationArg->getStr());
 					else if (annotationValueType == prt::AAT_BOOL)
-						annotationValue = py::cast(attr->getAnnotation(f)->getArgument(u)->getBool());
+						annotationValue = py::cast(annotationArg->getBool());
 					else if (annotationValueType == prt::AAT_FLOAT)
-						annotationValue = py::cast(attr->getAnnotation(f)->getArgument(u)->getFloat());
+						annotationValue = py::cast(annotationArg->getFloat());
 					else
 						annotationValue = py::cast("UNKNOWN_PARAMETER_VALUE_TYPE");
 
 					py::list annotationParameters;
-					annotationParameters.append(py::cast(attr->getAnnotation(f)->getArgument(u)->getKey()));
+					annotationParameters.append(py::cast(annotationArg->getKey()));
 					annotationParameters.append(annotationValue);
 					annotation.push_back(annotationParameters);
 				}

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -174,6 +174,79 @@ py::dict getRPKInfo(const std::filesystem::path& rulePackagePath) {
 	return ruleAttrs;
 }
 
+py::dict getRuleAttributesDeprecated(const prt::RuleFileInfo* ruleFileInfo) {
+	auto ruleAttrs = py::dict();
+
+	for (size_t i = 0; i < ruleFileInfo->getNumAttributes(); i++) {
+		bool hidden = false;
+		const prt::RuleFileInfo::Entry* attr = ruleFileInfo->getAttribute(i);
+
+		const std::wstring fullName(attr->getName());
+		if (fullName.find(L"Default$") != 0)
+			continue;
+		const std::wstring name = fullName.substr(8);
+		const prt::AnnotationArgumentType valueType = attr->getReturnType();
+		py::str type;
+
+		for (size_t f = 0; f < attr->getNumAnnotations(); f++) {
+			if (!(std::wcscmp(attr->getAnnotation(f)->getName(), ANNOT_HIDDEN))) {
+				hidden = true;
+				break;
+			}
+		}
+
+		if (!hidden) {
+			if (valueType == prt::AAT_STR)
+				type = "string";
+			else if (valueType == prt::AAT_BOOL)
+				type = "bool";
+			else if (valueType == prt::AAT_FLOAT)
+				type = "float";
+			else if (valueType == prt::AAT_STR_ARRAY)
+				type = "string[]";
+			else if (valueType == prt::AAT_BOOL_ARRAY)
+				type = "bool[]";
+			else if (valueType == prt::AAT_FLOAT_ARRAY)
+				type = "float[]";
+			else
+				type = "UNKNOWN_VALUE_TYPE";
+
+			ruleAttrs[py::cast(name)] = type;
+		}
+	}
+
+	return ruleAttrs;
+}
+
+py::dict inspectRPKDeprecated(const std::filesystem::path& rulePackagePath) {
+	PyErr_WarnEx(PyExc_DeprecationWarning, "inspect_rpk(rule_package_path) is deprecated, use get_rpk_attributes_info(rule_package_path) instead.", 1);
+	ResolveMapPtr resolveMap;
+
+	if (!std::filesystem::exists(rulePackagePath) || !pcu::getResolveMap(rulePackagePath, &resolveMap)) {
+		LOG_ERR << "invalid rule package path";
+		return py::dict();
+	}
+
+	std::wstring ruleFile = pcu::getRuleFileEntry(resolveMap.get());
+
+	const wchar_t* ruleFileURI = resolveMap->getString(ruleFile.c_str());
+	if (ruleFileURI == nullptr) {
+		LOG_ERR << "could not find rule file URI in resolve map of rule package " << rulePackagePath;
+		return py::dict();
+	}
+
+	prt::Status infoStatus = prt::STATUS_UNSPECIFIED_ERROR;
+	RuleFileInfoUPtr info(prt::createRuleFileInfo(ruleFileURI, nullptr, &infoStatus));
+	if (!info || infoStatus != prt::STATUS_OK) {
+		LOG_ERR << "could not get rule file info from rule file " << ruleFile;
+		return py::dict();
+	}
+
+	py::dict ruleAttrs = getRuleAttributesDeprecated(info.get());
+
+	return ruleAttrs;
+}
+
 } // namespace
 
 PYBIND11_MODULE(pyprt, m) {
@@ -186,6 +259,7 @@ PYBIND11_MODULE(pyprt, m) {
 	m.def("initialize_prt", &initializePRT, doc::Init);
 	m.def("is_prt_initialized", &isPRTInitialized, doc::IsInit);
 	m.def("shutdown_prt", &shutdownPRT, doc::Shutdown);
+	m.def("inspect_rpk", &inspectRPKDeprecated, py::arg("rulePackagePath"), doc::InspectRPK);
 	m.def("get_rpk_attributes_info", &getRPKInfo, py::arg("rulePackagePath"), doc::InspectRPK);
 
 	py::class_<InitialShape>(m, "InitialShape", doc::Is)

--- a/src/client/doc.h
+++ b/src/client/doc.h
@@ -37,10 +37,22 @@ constexpr const char* Shutdown =
         "Shutdown of PRT. The PRT initialization process can be done only once per "
         "session/script. Thus, ``initialize_prt()`` cannot be called after ``shutdown_prt()``.";
 
-constexpr const char* InspectRPK = R"mydelimiter(
+constexpr const char* InspectRPKDeprecated = R"mydelimiter(
         inspect_rpk(rule_package_path) -> dict
+        
+        Deprecated: use get_rpk_attributes_info(rule_package_path) instead.
 
         This function returns the CGA rule attributes name and value type for the specified rule package path.
+
+        :Returns:
+            dict
+    )mydelimiter";
+
+constexpr const char* GetRPKInfo = R"mydelimiter(
+        get_rpk_attributes_info(rule_package_path) -> dict
+
+        This function returns the CGA rule attributes name and value type for the specified rule package path as 
+        well as a list of the attributes annotations (annotation name, key(s) and value(s)).
 
         :Returns:
             dict

--- a/src/client/doc.h
+++ b/src/client/doc.h
@@ -52,7 +52,8 @@ constexpr const char* GetRPKInfo = R"mydelimiter(
         get_rpk_attributes_info(rule_package_path) -> dict
 
         This function returns the CGA rule attributes name and value type for the specified rule package path as 
-        well as a list of the attributes annotations (annotation name, key(s) and value(s)).
+        well as a list of the attributes annotations (annotation name, key(s) and value(s)). In case of an unnamed 
+        annotation parameter, its key is equal to ``'#NULL#'``, which can be read using the ``pyprt.NO_KEY`` constant.
 
         :Returns:
             dict

--- a/tests/inspectRPK_test.py
+++ b/tests/inspectRPK_test.py
@@ -26,7 +26,7 @@ def asset_file(filename):
 
 
 class InspectRPKTest(unittest.TestCase):
-    def test_candlerRPK(self):
+    def test_candler_rpk(self):
         rpk = asset_file('candler.rpk')
 
         inspect_dict = pyprt.get_rpk_attributes_info(rpk)
@@ -35,7 +35,7 @@ class InspectRPKTest(unittest.TestCase):
 
         self.assertSetEqual(set(inspect_dict.keys()), set(ground_truth_keys))
 
-    def test_candlerRPK_attr(self):
+    def test_candler_rpk_attr(self):
         rpk = asset_file('candler.rpk')
 
         inspect_dict = pyprt.get_rpk_attributes_info(rpk)

--- a/tests/inspectRPK_test.py
+++ b/tests/inspectRPK_test.py
@@ -39,7 +39,7 @@ class InspectRPKTest(unittest.TestCase):
         rpk = asset_file('candler.rpk')
 
         inspect_dict = pyprt.get_rpk_attributes_info(rpk)
-        ground_truth_dict = {'annotations': [['@Order', ['#NULL#', 3.0]],['@Range',['#NULL#', 0.5],['#NULL#', 2.0]],['@Group',['#NULL#', 'Windows'],['#NULL#', 4.0]]],
+        ground_truth_dict = {'annotations': [['@Order', ['NO_KEY', 3.0]],['@Range',['NO_KEY', 0.5],['NO_KEY', 2.0]],['@Group',['NO_KEY', 'Windows'],['NO_KEY', 4.0]]],
                              'type': 'float'}
 
         self.assertDictEqual(inspect_dict['RearWindowWidth'], ground_truth_dict)

--- a/tests/inspectRPK_test.py
+++ b/tests/inspectRPK_test.py
@@ -29,8 +29,17 @@ class InspectRPKTest(unittest.TestCase):
     def test_candlerRPK(self):
         rpk = asset_file('candler.rpk')
 
-        inspect_dict = pyprt.inspect_rpk(rpk)
-        ground_truth_dict = {'BuildingHeight': 'float', 'ColorizeWall': 'string', 'CornerWallWidth': 'float', 'CorniceOverhang': 'float', 'FloorHeight': 'float', 'FrontWindowWidth': 'float',
-                             'GroundfloorHeight': 'float', 'Mode': 'string', 'RearWindowWidth': 'float', 'SillSize': 'float', 'TileWidth': 'float', 'WallTexture': 'string', 'WindowHeight': 'float', 'streetWidth': 'float'}
+        inspect_dict = pyprt.get_rpk_attributes_info(rpk)
+        ground_truth_keys = ['BuildingHeight', 'ColorizeWall', 'CornerWallWidth', 'CorniceOverhang', 'FloorHeight', 'FrontWindowWidth',
+                             'GroundfloorHeight', 'Mode', 'RearWindowWidth', 'SillSize', 'TileWidth', 'WallTexture', 'WindowHeight', 'streetWidth']
 
-        self.assertDictEqual(inspect_dict, ground_truth_dict)
+        self.assertSetEqual(set(inspect_dict.keys()), set(ground_truth_keys))
+
+    def test_candlerRPK_attr(self):
+        rpk = asset_file('candler.rpk')
+
+        inspect_dict = pyprt.get_rpk_attributes_info(rpk)
+        ground_truth_dict = {'annotations': [['@Order', ['#NULL#', 3.0]],['@Range',['#NULL#', 0.5],['#NULL#', 2.0]],['@Group',['#NULL#', 'Windows'],['#NULL#', 4.0]]],
+                             'type': 'float'}
+
+        self.assertDictEqual(inspect_dict['RearWindowWidth'], ground_truth_dict)

--- a/tests/inspectRPK_test.py
+++ b/tests/inspectRPK_test.py
@@ -39,7 +39,7 @@ class InspectRPKTest(unittest.TestCase):
         rpk = asset_file('candler.rpk')
 
         inspect_dict = pyprt.get_rpk_attributes_info(rpk)
-        ground_truth_dict = {'annotations': [['@Order', ['NO_KEY', 3.0]],['@Range',['NO_KEY', 0.5],['NO_KEY', 2.0]],['@Group',['NO_KEY', 'Windows'],['NO_KEY', 4.0]]],
+        ground_truth_dict = {'annotations': [['@Order', ['#NULL#', 3.0]],['@Range',['#NULL#', 0.5],['#NULL#', 2.0]],['@Group',['#NULL#', 'Windows'],['#NULL#', 4.0]]],
                              'type': 'float'}
 
         self.assertDictEqual(inspect_dict['RearWindowWidth'], ground_truth_dict)

--- a/tests/multiGeneration_test.py
+++ b/tests/multiGeneration_test.py
@@ -26,7 +26,7 @@ def asset_file(filename):
 
 
 class MultiTest(unittest.TestCase):
-    def test_multiGenerations(self):
+    def test_multigenerations(self):
         rpk = asset_file('extrusion_rule.rpk')
         attrs = {}
         shape_geo = pyprt.InitialShape(
@@ -44,7 +44,7 @@ class MultiTest(unittest.TestCase):
         self.assertListEqual(model3[0].get_vertices(),
                              model4[0].get_vertices())
 
-    def test_PathAndGeometryInitShapes(self):
+    def test_path_geometry_init_shapes(self):
         rpk = asset_file('extrusion_rule.rpk')
         attrs = {}
         shape_geo = pyprt.InitialShape(

--- a/tests/pyGeometry_test.py
+++ b/tests/pyGeometry_test.py
@@ -30,7 +30,7 @@ def asset_output_file(filename):
 
 
 class GeometryTest(unittest.TestCase):
-    def test_verticesNber_candler(self):
+    def test_verticesnber_candler(self):
         rpk = asset_file('candler.rpk')
         attrs = {}
         shape_geo_from_obj = pyprt.InitialShape(
@@ -40,7 +40,7 @@ class GeometryTest(unittest.TestCase):
                                  'emitReport': False, 'emitGeometry': True})
         self.assertEqual(len(model[0].get_vertices()), 97050*3)
 
-    def test_facesNber_candler(self):
+    def test_facesnber_candler(self):
         rpk = asset_file('candler.rpk')
         attrs = {}
         shape_geo_from_obj = pyprt.InitialShape(
@@ -64,7 +64,7 @@ class GeometryTest(unittest.TestCase):
         rep_round = {x: round(z, 2) for x, z in rep.items()}
         self.assertEqual(rep_round, ground_truth_dict)
 
-    def test_noReport(self):
+    def test_noreport(self):
         rpk = asset_file('extrusion_rule.rpk')
         attrs = {}
         shape_geo = pyprt.InitialShape(
@@ -74,7 +74,7 @@ class GeometryTest(unittest.TestCase):
                                  'emitReport': False})
         self.assertDictEqual(model[0].get_report(), {})
 
-    def test_noGeometry(self):
+    def test_nogeometry(self):
         rpk = asset_file('extrusion_rule.rpk')
         attrs = {}
         shape_geo = pyprt.InitialShape(
@@ -84,7 +84,7 @@ class GeometryTest(unittest.TestCase):
                                  'emitGeometry': False})
         self.assertListEqual(model[0].get_vertices(), [])
 
-    def test_buildingHeight(self):
+    def test_buildingheight(self):
         rpk = asset_file('extrusion_rule.rpk')
         attrs = {}
         attrs2 = {'minBuildingHeight': 23.0,

--- a/tests/shapeAttributesDict_test.py
+++ b/tests/shapeAttributesDict_test.py
@@ -28,7 +28,7 @@ def asset_file(filename):
 
 class ShapeAttributesTest(unittest.TestCase):
 
-    def test_correctExecution(self):
+    def test_correct_execution(self):
         rpk = asset_file('extrusion_rule.rpk')
         attrs_1 = {}
         attrs_2 = {'minBuildingHeight': 30.0}
@@ -46,7 +46,7 @@ class ShapeAttributesTest(unittest.TestCase):
                                  {'emitReport': False, 'emitGeometry': True})
         self.assertEqual(len(model), 3)
 
-    def test_oneDictForAll(self):
+    def test_one_dict_for_all(self):
         rpk = asset_file('extrusion_rule.rpk')
         attrs = {}
         shape_geometry_1 = pyprt.InitialShape(
@@ -61,7 +61,7 @@ class ShapeAttributesTest(unittest.TestCase):
                                  {'emitReport': False, 'emitGeometry': True})
         self.assertEqual(len(model), 3)
 
-    def test_wrongNumberOfDict(self):
+    def test_wrong_number_of_dict(self):
         rpk = asset_file('extrusion_rule.rpk')
         attrs_1 = {}
         attrs_2 = {'minBuildingHeight': 30.0}
@@ -77,7 +77,7 @@ class ShapeAttributesTest(unittest.TestCase):
                                  {'emitReport': False, 'emitGeometry': True})
         self.assertEqual(len(model), 0)
 
-    def test_oneDictPerInitialShapeType(self):
+    def test_one_dict_per_initial_shape_type(self):
         rpk = asset_file('extrusion_rule.rpk')
         attrs_1 = {}
         attrs_2 = {'minBuildingHeight': 30.0}
@@ -91,7 +91,7 @@ class ShapeAttributesTest(unittest.TestCase):
         self.assertNotEqual(model[0].get_report()[
                             'Min Height.0_avg'], model[1].get_report()['Min Height.0_avg'])
 
-    def test_arrayAttributes(self):
+    def test_array_attributes(self):
         with tempfile.TemporaryDirectory() as output_path:
             rpk = asset_file('arrayAttrs.rpk')
             attrs = {'ruleFile': 'bin/arrayAttrs.cgb',


### PR DESCRIPTION
Function output example:

`{'BuildingColor' : { 'type' : 'string',' annotations' : [ ['@Color'] ] },
'BuildingForm'  : { 'type' : 'string', 'annotations' : [ ['@Enum', [ '#NULL#', 'rectangle' ], [ '#NULL#', 'circle'] ], 
                                                           ['@Order', [ '#NULL#', 2] ] ] } }`

Details:
The main dictionary keys are the rule attributes name. The values are a dictionary including the attribute type (float, string or boolean) and the attribute annotation(s). The annotations are stored as a list of lists. Each sub-list contains the parameters of one annotation (index 0: annotation name, indices 1 to n: list of parameters with name and value). (The "#NULL#" means that this is a un-named parameter.)