### PR TITLE
Access rule attributes values of a generated model

### DIFF
--- a/src/client/GeneratedModel.cpp
+++ b/src/client/GeneratedModel.cpp
@@ -23,4 +23,4 @@ GeneratedModel::GeneratedModel(const size_t& initShapeIdx, const Coordinates& ve
                                const Indices& face, const pybind11::dict& rep, const std::wstring& cgaPrints,
                                const std::vector<std::wstring>& cgaErrors, const pybind11::dict& attrVal)
     : mInitialShapeIndex(initShapeIdx), mVertices(vert), mIndices(indices), mFaces(face), mReport(rep),
-      mCGAPrints(cgaPrints), mCGAErrors(cgaErrors), mAttributesVal(attrVal) {}
+      mCGAPrints(cgaPrints), mCGAErrors(cgaErrors), mAttributes(attrVal) {}

--- a/src/client/GeneratedModel.cpp
+++ b/src/client/GeneratedModel.cpp
@@ -21,6 +21,6 @@
 
 GeneratedModel::GeneratedModel(const size_t& initShapeIdx, const Coordinates& vert, const Indices& indices,
                                const Indices& face, const pybind11::dict& rep, const std::wstring& cgaPrints,
-                               const std::vector<std::wstring>& cgaErrors)
+                               const std::vector<std::wstring>& cgaErrors, const pybind11::dict& attrVal)
     : mInitialShapeIndex(initShapeIdx), mVertices(vert), mIndices(indices), mFaces(face), mReport(rep),
-      mCGAPrints(cgaPrints), mCGAErrors(cgaErrors) {}
+      mCGAPrints(cgaPrints), mCGAErrors(cgaErrors), mAttributesVal(attrVal) {}

--- a/src/client/GeneratedModel.h
+++ b/src/client/GeneratedModel.h
@@ -56,8 +56,8 @@ public:
 	const std::vector<std::wstring>& getCGAErrors() const {
 		return mCGAErrors;
 	}
-	const pybind11::dict& getAttributesValues() const {
-		return mAttributesVal;
+	const pybind11::dict& getAttributes() const {
+		return mAttributes;
 	}
 
 private:
@@ -68,7 +68,7 @@ private:
 	pybind11::dict mReport;
 	std::wstring mCGAPrints;
 	std::vector<std::wstring> mCGAErrors;
-	pybind11::dict mAttributesVal;
+	pybind11::dict mAttributes;
 };
 
 PYBIND11_MAKE_OPAQUE(std::vector<GeneratedModel>);

--- a/src/client/GeneratedModel.h
+++ b/src/client/GeneratedModel.h
@@ -30,7 +30,8 @@
 class GeneratedModel {
 public:
 	GeneratedModel(const size_t& initialShapeIdx, const Coordinates& vert, const Indices& indices, const Indices& face,
-	               const pybind11::dict& rep, const std::wstring& cgaPrints, const std::vector<std::wstring>& cgaErrors);
+	               const pybind11::dict& rep, const std::wstring& cgaPrints, const std::vector<std::wstring>& cgaErrors,
+				   const pybind11::dict& attrVal);
 	GeneratedModel() = default;
 	~GeneratedModel() = default;
 
@@ -55,6 +56,9 @@ public:
 	const std::vector<std::wstring>& getCGAErrors() const {
 		return mCGAErrors;
 	}
+	const pybind11::dict& getAttributesValues() const {
+		return mAttributesVal;
+	}
 
 private:
 	size_t mInitialShapeIndex;
@@ -64,6 +68,7 @@ private:
 	pybind11::dict mReport;
 	std::wstring mCGAPrints;
 	std::vector<std::wstring> mCGAErrors;
+	pybind11::dict mAttributesVal;
 };
 
 PYBIND11_MAKE_OPAQUE(std::vector<GeneratedModel>);

--- a/src/client/ModelGenerator.cpp
+++ b/src/client/ModelGenerator.cpp
@@ -293,7 +293,7 @@ std::vector<GeneratedModel> ModelGenerator::generateModel(const std::vector<py::
 	return newGeneratedGeo;
 }
 
-std::vector<GeneratedModel> ModelGenerator::generateAnotherModel(const std::vector<py::dict>& shapeAttributes) {
+std::vector<GeneratedModel> ModelGenerator::generateAnotherModel(const std::vector<py::dict>&) {
 	const char* message = "generate_model(shape_attributes) has been removed, use "
 	                      "generate_model(shape_attributes, rule_package_path, "
 	                      "geometry_encoder, encoder_options) instead.";

--- a/src/client/ModelGenerator.cpp
+++ b/src/client/ModelGenerator.cpp
@@ -139,7 +139,7 @@ void ModelGenerator::initializeEncoderData(const std::wstring& encName, const py
 }
 
 prt::Status ModelGenerator::initializeRulePackageData(const std::filesystem::path& rulePackagePath, ResolveMapPtr& resolveMap,
-	CachePtr& cache) {
+	CachePtr& cache, RuleFileInfoUPtr& ruleInfo) {
 	if (!std::filesystem::exists(rulePackagePath)) {
 		LOG_ERR << "The rule package path is unvalid.";
 		return prt::STATUS_FILE_NOT_FOUND;
@@ -164,6 +164,7 @@ prt::Status ModelGenerator::initializeRulePackageData(const std::filesystem::pat
 	}
 
 	mStartRule = pcu::detectStartRule(info);
+	ruleInfo = std::move(info);
 	return prt::STATUS_OK;
 }
 
@@ -197,7 +198,8 @@ std::vector<GeneratedModel> ModelGenerator::generateModel(const std::vector<py::
 		}
 
 		// Rule package
-		prt::Status rpkStat = initializeRulePackageData(rulePackagePath, mResolveMap, mCache);
+		RuleFileInfoUPtr ruleInfo;
+		prt::Status rpkStat = initializeRulePackageData(rulePackagePath, mResolveMap, mCache, ruleInfo);
 		
 		if (rpkStat != prt::STATUS_OK)
 			return {};
@@ -221,7 +223,7 @@ std::vector<GeneratedModel> ModelGenerator::generateModel(const std::vector<py::
 
 		if (geometryEncoderName == ENCODER_ID_PYTHON) {
 
-			PyCallbacksPtr foc{std::make_unique<PyCallbacks>(mInitialShapesBuilders.size())};
+			PyCallbacksPtr foc{std::make_unique<PyCallbacks>(mInitialShapesBuilders.size(), std::move(ruleInfo))};
 
 			// Generate
 			const prt::Status genStat =

--- a/src/client/ModelGenerator.cpp
+++ b/src/client/ModelGenerator.cpp
@@ -239,7 +239,7 @@ std::vector<GeneratedModel> ModelGenerator::generateModel(const std::vector<py::
 			for (size_t idx = 0; idx < mInitialShapesBuilders.size(); idx++) {
 				newGeneratedGeo.emplace_back(idx, foc->getVertices(idx), foc->getIndices(idx), foc->getFaces(idx),
 				                             foc->getReport(idx), foc->getCGAPrints(idx), foc->getCGAErrors(idx),
-											 foc->getAttributesValues(idx));
+											 foc->getAttributes(idx));
 			}
 		}
 		else {

--- a/src/client/ModelGenerator.cpp
+++ b/src/client/ModelGenerator.cpp
@@ -29,6 +29,7 @@ namespace {
 const std::wstring ENCODER_ID_CGA_REPORT = L"com.esri.prt.core.CGAReportEncoder";
 const std::wstring ENCODER_ID_CGA_PRINT = L"com.esri.prt.core.CGAPrintEncoder";
 const std::wstring ENCODER_ID_CGA_ERROR = L"com.esri.prt.core.CGAErrorEncoder";
+const std::wstring ENCODER_ID_ATTR_EVAL = L"com.esri.prt.core.AttributeEvalEncoder";
 const std::wstring ENCODER_ID_PYTHON = L"com.esri.pyprt.PyEncoder";
 
 constexpr const char* ENC_OPT_OUTPUT_PATH = "outputPath";
@@ -123,15 +124,18 @@ void ModelGenerator::initializeEncoderData(const std::wstring& encName, const py
 	mEncodersNames.push_back(ENCODER_ID_CGA_REPORT);
 	mEncodersNames.push_back(ENCODER_ID_CGA_PRINT);
 	mEncodersNames.push_back(ENCODER_ID_CGA_ERROR);
+	mEncodersNames.push_back(ENCODER_ID_ATTR_EVAL);
 
 	const AttributeMapBuilderPtr optionsBuilder{prt::AttributeMapBuilder::create()};
 	const AttributeMapPtr reportOptions{optionsBuilder->createAttributeMapAndReset()};
 	const AttributeMapPtr printOptions{optionsBuilder->createAttributeMapAndReset()};
 	const AttributeMapPtr errorOptions{optionsBuilder->createAttributeMapAndReset()};
+	const AttributeMapPtr attrOptions{optionsBuilder->createAttributeMapAndReset()};
 
 	mEncodersOptionsPtr.push_back(pcu::createValidatedOptions(ENCODER_ID_CGA_REPORT, reportOptions));
 	mEncodersOptionsPtr.push_back(pcu::createValidatedOptions(ENCODER_ID_CGA_PRINT, printOptions));
 	mEncodersOptionsPtr.push_back(pcu::createValidatedOptions(ENCODER_ID_CGA_ERROR, errorOptions));
+	mEncodersOptionsPtr.push_back(pcu::createValidatedOptions(ENCODER_ID_ATTR_EVAL, attrOptions));
 }
 
 prt::Status ModelGenerator::initializeRulePackageData(const std::filesystem::path& rulePackagePath, ResolveMapPtr& resolveMap,
@@ -232,7 +236,8 @@ std::vector<GeneratedModel> ModelGenerator::generateModel(const std::vector<py::
 
 			for (size_t idx = 0; idx < mInitialShapesBuilders.size(); idx++) {
 				newGeneratedGeo.emplace_back(idx, foc->getVertices(idx), foc->getIndices(idx), foc->getFaces(idx),
-				                             foc->getReport(idx), foc->getCGAPrints(idx), foc->getCGAErrors(idx));
+				                             foc->getReport(idx), foc->getCGAPrints(idx), foc->getCGAErrors(idx),
+											 foc->getAttributesValues(idx));
 			}
 		}
 		else {

--- a/src/client/ModelGenerator.cpp
+++ b/src/client/ModelGenerator.cpp
@@ -139,7 +139,7 @@ void ModelGenerator::initializeEncoderData(const std::wstring& encName, const py
 }
 
 prt::Status ModelGenerator::initializeRulePackageData(const std::filesystem::path& rulePackagePath, ResolveMapPtr& resolveMap,
-	CachePtr& cache, RuleFileInfoUPtr& ruleInfo) {
+	CachePtr& cache) {
 	if (!std::filesystem::exists(rulePackagePath)) {
 		LOG_ERR << "The rule package path is unvalid.";
 		return prt::STATUS_FILE_NOT_FOUND;
@@ -164,7 +164,7 @@ prt::Status ModelGenerator::initializeRulePackageData(const std::filesystem::pat
 	}
 
 	mStartRule = pcu::detectStartRule(info);
-	ruleInfo = std::move(info);
+	mHiddenAttrs = pcu::getHiddenAttributes(info);
 	return prt::STATUS_OK;
 }
 
@@ -199,7 +199,7 @@ std::vector<GeneratedModel> ModelGenerator::generateModel(const std::vector<py::
 
 		// Rule package
 		RuleFileInfoUPtr ruleInfo;
-		prt::Status rpkStat = initializeRulePackageData(rulePackagePath, mResolveMap, mCache, ruleInfo);
+		prt::Status rpkStat = initializeRulePackageData(rulePackagePath, mResolveMap, mCache);
 		
 		if (rpkStat != prt::STATUS_OK)
 			return {};
@@ -223,7 +223,7 @@ std::vector<GeneratedModel> ModelGenerator::generateModel(const std::vector<py::
 
 		if (geometryEncoderName == ENCODER_ID_PYTHON) {
 
-			PyCallbacksPtr foc{std::make_unique<PyCallbacks>(mInitialShapesBuilders.size(), std::move(ruleInfo))};
+			PyCallbacksPtr foc{std::make_unique<PyCallbacks>(mInitialShapesBuilders.size(), mHiddenAttrs)};
 
 			// Generate
 			const prt::Status genStat =

--- a/src/client/ModelGenerator.h
+++ b/src/client/ModelGenerator.h
@@ -62,5 +62,5 @@ private:
 	                              std::vector<AttributeMapPtr>& convertShapeAttr);
 	void initializeEncoderData(const std::wstring& encName, const pybind11::dict& encOpt);
 	prt::Status initializeRulePackageData(const std::filesystem::path& rulePackagePath, ResolveMapPtr& resolveMap,
-	                               CachePtr& cache);
+	                                      CachePtr& cache, RuleFileInfoUPtr& info);
 };

--- a/src/client/ModelGenerator.h
+++ b/src/client/ModelGenerator.h
@@ -51,6 +51,7 @@ private:
 
 	std::wstring mRuleFile;
 	std::wstring mStartRule;
+	std::vector<std::wstring> mHiddenAttrs;
 	int32_t mSeed = 0;
 	std::wstring mShapeName = L"InitialShape";
 
@@ -62,5 +63,5 @@ private:
 	                              std::vector<AttributeMapPtr>& convertShapeAttr);
 	void initializeEncoderData(const std::wstring& encName, const pybind11::dict& encOpt);
 	prt::Status initializeRulePackageData(const std::filesystem::path& rulePackagePath, ResolveMapPtr& resolveMap,
-	                                      CachePtr& cache, RuleFileInfoUPtr& info);
+	                                      CachePtr& cache);
 };

--- a/src/client/ModelGenerator.h
+++ b/src/client/ModelGenerator.h
@@ -51,7 +51,7 @@ private:
 
 	std::wstring mRuleFile;
 	std::wstring mStartRule;
-	std::vector<std::wstring> mHiddenAttrs;
+	std::unordered_set<std::wstring> mHiddenAttrs;
 	int32_t mSeed = 0;
 	std::wstring mShapeName = L"InitialShape";
 

--- a/src/client/PyCallbacks.cpp
+++ b/src/client/PyCallbacks.cpp
@@ -24,6 +24,28 @@
 
 namespace py = pybind11;
 
+bool PyCallbacks::isHiddenAttribute(const RuleFileInfoUPtr& ruleFileInfo, const wchar_t* key) {
+	for (size_t ai = 0, numAttrs = ruleFileInfo->getNumAttributes(); ai < numAttrs; ai++) {
+		const auto attr = ruleFileInfo->getAttribute(ai);
+		if (std::wcscmp(key, attr->getName()) == 0) {
+			for (size_t k = 0, numAnns = attr->getNumAnnotations(); k < numAnns; k++) {
+				if (std::wcscmp(attr->getAnnotation(k)->getName(), L"@Hidden") == 0)
+					return true;
+			}
+			return false;
+		}
+	}
+	return false;
+}
+
+std::wstring PyCallbacks::removeDefaultStyleName(const wchar_t* key) {
+	const std::wstring keyName = key;
+	if (keyName.find(L"Default$") == 0)
+		return keyName.substr(8);
+	else
+		return keyName;
+}
+
 void PyCallbacks::addGeometry(const size_t initialShapeIndex, const double* vertexCoords,
                               const size_t vertexCoordsCount, const uint32_t* faceIndices,
                               const size_t faceIndicesCount, const uint32_t* faceCounts, const size_t faceCountsCount) {

--- a/src/client/PyCallbacks.cpp
+++ b/src/client/PyCallbacks.cpp
@@ -36,9 +36,11 @@ prt::Status PyCallbacks::storeAttr(size_t isIndex, const wchar_t* key, const T v
 }
 
 bool PyCallbacks::isHiddenAttribute(const wchar_t* key) {
-	std::vector<std::wstring>::iterator it = find(mHiddenAttrs.begin(), mHiddenAttrs.end(), key);
-	if (it != mHiddenAttrs.end())
-		return true;
+	if (key != nullptr) {
+		std::vector<std::wstring>::iterator it = find(mHiddenAttrs.begin(), mHiddenAttrs.end(), key);
+		if (it != mHiddenAttrs.end())
+			return true;
+	}
 	
 	return false;
 }

--- a/src/client/PyCallbacks.cpp
+++ b/src/client/PyCallbacks.cpp
@@ -84,3 +84,30 @@ void PyCallbacks::addReports(const size_t initialShapeIndex, const wchar_t** str
 		currentModel.mCGAReport[pyKey] = stringReportValues[i];
 	}
 }
+
+prt::Status PyCallbacks::attrBool(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, bool value) {
+	if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
+		py::object pyKey = py::cast(removeDefaultStyleName(key));
+		mModels[isIndex].mAttrVal[pyKey] = value;
+	}
+
+	return prt::STATUS_OK;
+}
+
+	prt::Status PyCallbacks::attrFloat(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, double value) {
+	if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
+		py::object pyKey = py::cast(removeDefaultStyleName(key));
+		mModels[isIndex].mAttrVal[pyKey] = value;
+	}
+
+	return prt::STATUS_OK;
+}
+
+prt::Status PyCallbacks::attrString(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, const wchar_t* value) {
+	if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
+		py::object pyKey = py::cast(removeDefaultStyleName(key));
+		mModels[isIndex].mAttrVal[pyKey] = value;
+	}
+
+	return prt::STATUS_OK;
+}

--- a/src/client/PyCallbacks.cpp
+++ b/src/client/PyCallbacks.cpp
@@ -37,7 +37,7 @@ prt::Status PyCallbacks::storeAttr(size_t isIndex, const wchar_t* key, const T v
 
 bool PyCallbacks::isHiddenAttribute(const wchar_t* key) {
 	if (key != nullptr) {
-		std::vector<std::wstring>::iterator it = find(mHiddenAttrs.begin(), mHiddenAttrs.end(), key);
+		std::unordered_set<std::wstring>::iterator it = find(mHiddenAttrs.begin(), mHiddenAttrs.end(), key);
 		if (it != mHiddenAttrs.end())
 			return true;
 	}

--- a/src/client/PyCallbacks.cpp
+++ b/src/client/PyCallbacks.cpp
@@ -24,6 +24,16 @@
 
 namespace py = pybind11;
 
+template <typename T>
+prt::Status PyCallbacks::storeAttr(size_t isIndex, const wchar_t* key, const T value) {
+	if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
+		py::object pyKey = py::cast(removeDefaultStyleName(key));
+		mModels[isIndex].mAttrVal[pyKey] = value;
+	}
+
+	return prt::STATUS_OK;
+}
+
 bool PyCallbacks::isHiddenAttribute(const RuleFileInfoUPtr& ruleFileInfo, const wchar_t* key) {
 	for (size_t ai = 0, numAttrs = ruleFileInfo->getNumAttributes(); ai < numAttrs; ai++) {
 		const auto attr = ruleFileInfo->getAttribute(ai);
@@ -86,28 +96,14 @@ void PyCallbacks::addReports(const size_t initialShapeIndex, const wchar_t** str
 }
 
 prt::Status PyCallbacks::attrBool(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, bool value) {
-	if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
-		py::object pyKey = py::cast(removeDefaultStyleName(key));
-		mModels[isIndex].mAttrVal[pyKey] = value;
-	}
-
-	return prt::STATUS_OK;
+	return storeAttr(isIndex, key, value);
 }
 
-	prt::Status PyCallbacks::attrFloat(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, double value) {
-	if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
-		py::object pyKey = py::cast(removeDefaultStyleName(key));
-		mModels[isIndex].mAttrVal[pyKey] = value;
-	}
-
-	return prt::STATUS_OK;
+prt::Status PyCallbacks::attrFloat(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, double value) {
+	return storeAttr(isIndex, key, value);
 }
 
-prt::Status PyCallbacks::attrString(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, const wchar_t* value) {
-	if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
-		py::object pyKey = py::cast(removeDefaultStyleName(key));
-		mModels[isIndex].mAttrVal[pyKey] = value;
-	}
-
-	return prt::STATUS_OK;
+prt::Status PyCallbacks::attrString(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key,
+                                    const wchar_t* value) {
+	return storeAttr(isIndex, key, value);
 }

--- a/src/client/PyCallbacks.cpp
+++ b/src/client/PyCallbacks.cpp
@@ -37,7 +37,7 @@ prt::Status PyCallbacks::storeAttr(size_t isIndex, const wchar_t* key, const T v
 
 bool PyCallbacks::isHiddenAttribute(const wchar_t* key) {
 	if (key != nullptr) {
-		std::unordered_set<std::wstring>::iterator it = find(mHiddenAttrs.begin(), mHiddenAttrs.end(), key);
+		std::unordered_set<std::wstring>::iterator it = std::find(mHiddenAttrs.begin(), mHiddenAttrs.end(), key);
 		if (it != mHiddenAttrs.end())
 			return true;
 	}

--- a/src/client/PyCallbacks.h
+++ b/src/client/PyCallbacks.h
@@ -53,12 +53,12 @@ private:
 	};
 
 	std::vector<Model> mModels;
-	RuleFileInfoUPtr mRuleFileInfo;
+	std::vector<std::wstring> mHiddenAttrs;
 
 public:
-	PyCallbacks(const size_t initialShapeCount, RuleFileInfoUPtr& ruleFileInfo) {
+	PyCallbacks(const size_t initialShapeCount, std::vector<std::wstring>& hiddenAttrs) {
 		mModels.resize(initialShapeCount);
-		mRuleFileInfo = std::move(ruleFileInfo);
+		mHiddenAttrs = hiddenAttrs;
 	}
 
 	virtual ~PyCallbacks() = default;
@@ -66,9 +66,7 @@ public:
 	template <typename T>
 	prt::Status storeAttr(size_t isIndex, const wchar_t* key, const T value);
 
-	bool isHiddenAttribute(const RuleFileInfoUPtr& ruleFileInfo, const wchar_t* key);
-
-	std::wstring removeDefaultStyleName(const wchar_t* key);
+	bool isHiddenAttribute(const wchar_t* key);
 
 	void addGeometry(const size_t initialShapeIndex, const double* vertexCoords, const size_t vextexCoordsCount,
 	                 const uint32_t* faceIndices, const size_t faceIndicesCount, const uint32_t* faceCounts,

--- a/src/client/PyCallbacks.h
+++ b/src/client/PyCallbacks.h
@@ -63,6 +63,9 @@ public:
 
 	virtual ~PyCallbacks() = default;
 
+	template <typename T>
+	prt::Status storeAttr(size_t isIndex, const wchar_t* key, const T value);
+
 	bool isHiddenAttribute(const RuleFileInfoUPtr& ruleFileInfo, const wchar_t* key);
 
 	std::wstring removeDefaultStyleName(const wchar_t* key);

--- a/src/client/PyCallbacks.h
+++ b/src/client/PyCallbacks.h
@@ -56,7 +56,7 @@ private:
 	std::vector<std::wstring> mHiddenAttrs;
 
 public:
-	PyCallbacks(const size_t initialShapeCount, std::vector<std::wstring>& hiddenAttrs) {
+	PyCallbacks(const size_t initialShapeCount, const std::vector<std::wstring>& hiddenAttrs) {
 		mModels.resize(initialShapeCount);
 		mHiddenAttrs = hiddenAttrs;
 	}

--- a/src/client/PyCallbacks.h
+++ b/src/client/PyCallbacks.h
@@ -171,33 +171,11 @@ public:
 		return prt::STATUS_OK;
 	}
 
-	prt::Status attrBool(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, bool value) override {
-		if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
-			py::object pyKey = py::cast(removeDefaultStyleName(key));
-			mModels[isIndex].mAttrVal[pyKey] = value;
-		}
+	prt::Status attrBool(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, bool value) override;
 
-		return prt::STATUS_OK;
-	}
+	prt::Status attrFloat(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, double value) override;
 
-	prt::Status attrFloat(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, double value) override {
-		if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
-			py::object pyKey = py::cast(removeDefaultStyleName(key));
-			mModels[isIndex].mAttrVal[pyKey] = value;
-		}
-
-		return prt::STATUS_OK;
-	}
-
-	prt::Status attrString(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key,
-	                       const wchar_t* value) override {
-		if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
-			py::object pyKey = py::cast(removeDefaultStyleName(key));
-			mModels[isIndex].mAttrVal[pyKey] = value;
-		}
-
-		return prt::STATUS_OK;
-	}
+	prt::Status attrString(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, const wchar_t* value) override;
 
 	prt::Status attrBoolArray(size_t /*isIndex*/, int32_t /*shapeID*/, const wchar_t* /*key*/, const bool* /*ptr*/,
 	                          size_t /*size*/, size_t /*nRows*/) override {

--- a/src/client/PyCallbacks.h
+++ b/src/client/PyCallbacks.h
@@ -122,7 +122,7 @@ public:
 		return mModels[initialShapeIdx].mCGAErrors;
 	}
 
-	const py::dict& getAttributesValues(const size_t initialShapeIdx) const {
+	const py::dict& getAttributes(const size_t initialShapeIdx) const {
 		if (initialShapeIdx >= mModels.size())
 			throw std::out_of_range("initial shape index is out of range.");
 

--- a/src/client/PyCallbacks.h
+++ b/src/client/PyCallbacks.h
@@ -53,13 +53,19 @@ private:
 	};
 
 	std::vector<Model> mModels;
+	RuleFileInfoUPtr mRuleFileInfo;
 
 public:
-	PyCallbacks(const size_t initialShapeCount) {
+	PyCallbacks(const size_t initialShapeCount, RuleFileInfoUPtr& ruleFileInfo) {
 		mModels.resize(initialShapeCount);
+		mRuleFileInfo = std::move(ruleFileInfo);
 	}
 
 	virtual ~PyCallbacks() = default;
+
+	bool isHiddenAttribute(const RuleFileInfoUPtr& ruleFileInfo, const wchar_t* key);
+
+	std::wstring removeDefaultStyleName(const wchar_t* key);
 
 	void addGeometry(const size_t initialShapeIndex, const double* vertexCoords, const size_t vextexCoordsCount,
 	                 const uint32_t* faceIndices, const size_t faceIndicesCount, const uint32_t* faceCounts,
@@ -166,23 +172,29 @@ public:
 	}
 
 	prt::Status attrBool(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, bool value) override {
-		py::object pyKey = py::cast(key);
-		mModels[isIndex].mAttrVal[pyKey] = value;
+		if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
+			py::object pyKey = py::cast(removeDefaultStyleName(key));
+			mModels[isIndex].mAttrVal[pyKey] = value;
+		}
 
 		return prt::STATUS_OK;
 	}
 
 	prt::Status attrFloat(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, double value) override {
-		py::object pyKey = py::cast(key);
-		mModels[isIndex].mAttrVal[pyKey] = value;
+		if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
+			py::object pyKey = py::cast(removeDefaultStyleName(key));
+			mModels[isIndex].mAttrVal[pyKey] = value;
+		}
 
 		return prt::STATUS_OK;
 	}
 
 	prt::Status attrString(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key,
 	                       const wchar_t* value) override {
-		py::object pyKey = py::cast(key);
-		mModels[isIndex].mAttrVal[pyKey] = value;
+		if (mRuleFileInfo && !isHiddenAttribute(mRuleFileInfo, key)) {
+			py::object pyKey = py::cast(removeDefaultStyleName(key));
+			mModels[isIndex].mAttrVal[pyKey] = value;
+		}
 
 		return prt::STATUS_OK;
 	}

--- a/src/client/PyCallbacks.h
+++ b/src/client/PyCallbacks.h
@@ -49,6 +49,7 @@ private:
 		py::dict mCGAReport;
 		std::wstring mCGAPrints;
 		std::vector<std::wstring> mCGAErrors;
+		py::dict mAttrVal;
 	};
 
 	std::vector<Model> mModels;
@@ -115,6 +116,13 @@ public:
 		return mModels[initialShapeIdx].mCGAErrors;
 	}
 
+	const py::dict& getAttributesValues(const size_t initialShapeIdx) const {
+		if (initialShapeIdx >= mModels.size())
+			throw std::out_of_range("initial shape index is out of range.");
+
+		return mModels[initialShapeIdx].mAttrVal;
+	}
+
 	prt::Status generateError(size_t /*isIndex*/, prt::Status /*status*/, const wchar_t* /*message*/) override {
 		return prt::STATUS_OK;
 	}
@@ -157,16 +165,25 @@ public:
 		return prt::STATUS_OK;
 	}
 
-	prt::Status attrBool(size_t /*isIndex*/, int32_t /*shapeID*/, const wchar_t* /*key*/, bool /*value*/) override {
+	prt::Status attrBool(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, bool value) override {
+		py::object pyKey = py::cast(key);
+		mModels[isIndex].mAttrVal[pyKey] = value;
+
 		return prt::STATUS_OK;
 	}
 
-	prt::Status attrFloat(size_t /*isIndex*/, int32_t /*shapeID*/, const wchar_t* /*key*/, double /*value*/) override {
+	prt::Status attrFloat(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key, double value) override {
+		py::object pyKey = py::cast(key);
+		mModels[isIndex].mAttrVal[pyKey] = value;
+
 		return prt::STATUS_OK;
 	}
 
-	prt::Status attrString(size_t /*isIndex*/, int32_t /*shapeID*/, const wchar_t* /*key*/,
-	                       const wchar_t* /*value*/) override {
+	prt::Status attrString(size_t isIndex, int32_t /*shapeID*/, const wchar_t* key,
+	                       const wchar_t* value) override {
+		py::object pyKey = py::cast(key);
+		mModels[isIndex].mAttrVal[pyKey] = value;
+
 		return prt::STATUS_OK;
 	}
 

--- a/src/client/PyCallbacks.h
+++ b/src/client/PyCallbacks.h
@@ -53,10 +53,10 @@ private:
 	};
 
 	std::vector<Model> mModels;
-	std::vector<std::wstring> mHiddenAttrs;
+	std::unordered_set<std::wstring> mHiddenAttrs;
 
 public:
-	PyCallbacks(const size_t initialShapeCount, const std::vector<std::wstring>& hiddenAttrs) {
+	PyCallbacks(const size_t initialShapeCount, const std::unordered_set<std::wstring>& hiddenAttrs) {
 		mModels.resize(initialShapeCount);
 		mHiddenAttrs = hiddenAttrs;
 	}

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -275,7 +275,8 @@ PYBIND11_MODULE(pyprt, m) {
 	        .def("get_faces", &GeneratedModel::getFaces, doc::GmGetF)
 	        .def("get_report", &GeneratedModel::getReport, doc::GmGetR)
 	        .def("get_cga_prints", &GeneratedModel::getCGAPrints, doc::GmGetP)
-	        .def("get_cga_errors", &GeneratedModel::getCGAErrors, doc::GmGetE);
+	        .def("get_cga_errors", &GeneratedModel::getCGAErrors, doc::GmGetE)
+			.def("get_attributes_values", &GeneratedModel::getAttributesValues);
 
 	py::class_<std::filesystem::path>(m, "Path").def(py::init<std::string>());
 	py::implicitly_convertible<std::string, std::filesystem::path>();

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -276,7 +276,7 @@ PYBIND11_MODULE(pyprt, m) {
 	        .def("get_report", &GeneratedModel::getReport, doc::GmGetR)
 	        .def("get_cga_prints", &GeneratedModel::getCGAPrints, doc::GmGetP)
 	        .def("get_cga_errors", &GeneratedModel::getCGAErrors, doc::GmGetE)
-			.def("get_attributes_values", &GeneratedModel::getAttributesValues);
+			.def("get_attributes_values", &GeneratedModel::getAttributesValues, doc::GmGetAttr);
 
 	py::class_<std::filesystem::path>(m, "Path").def(py::init<std::string>());
 	py::implicitly_convertible<std::string, std::filesystem::path>();

--- a/src/client/api.cpp
+++ b/src/client/api.cpp
@@ -276,7 +276,7 @@ PYBIND11_MODULE(pyprt, m) {
 	        .def("get_report", &GeneratedModel::getReport, doc::GmGetR)
 	        .def("get_cga_prints", &GeneratedModel::getCGAPrints, doc::GmGetP)
 	        .def("get_cga_errors", &GeneratedModel::getCGAErrors, doc::GmGetE)
-			.def("get_attributes_values", &GeneratedModel::getAttributesValues, doc::GmGetAttr);
+			.def("get_attributes", &GeneratedModel::getAttributes, doc::GmGetAttr);
 
 	py::class_<std::filesystem::path>(m, "Path").def(py::init<std::string>());
 	py::implicitly_convertible<std::string, std::filesystem::path>();

--- a/src/client/doc.h
+++ b/src/client/doc.h
@@ -277,4 +277,13 @@ constexpr const char* GmGetE = R"mydelimiter(
             List[str]
         )mydelimiter";
 
+constexpr const char* GmGetAttr = R"mydelimiter(
+        get_attributes_values() -> dict
+
+        Returns a dictionary with the CGA rule attributes name and value used to generate this model.
+
+        :Returns:
+            dict
+        )mydelimiter";
+
 } // namespace doc

--- a/src/client/doc.h
+++ b/src/client/doc.h
@@ -278,7 +278,7 @@ constexpr const char* GmGetE = R"mydelimiter(
         )mydelimiter";
 
 constexpr const char* GmGetAttr = R"mydelimiter(
-        get_attributes_values() -> dict
+        get_attributes() -> dict
 
         Returns a dictionary with the CGA rule attributes name and value used to generate this model.
 

--- a/src/client/utils.cpp
+++ b/src/client/utils.cpp
@@ -117,6 +117,28 @@ std::wstring detectStartRule(const RuleFileInfoUPtr& ruleFileInfo) {
 	return {};
 }
 
+std::vector<std::wstring> getHiddenAttributes(const RuleFileInfoUPtr& ruleFileInfo) {
+	std::vector<std::wstring> hiddenVec;
+
+	for (size_t ai = 0, numAttrs = ruleFileInfo->getNumAttributes(); ai < numAttrs; ai++) {
+		const auto attr = ruleFileInfo->getAttribute(ai);
+		for (size_t k = 0, numAnns = attr->getNumAnnotations(); k < numAnns; k++) {
+			if (std::wcscmp(attr->getAnnotation(k)->getName(), L"@Hidden") == 0)
+				hiddenVec.push_back(attr->getName());
+		}
+	}
+
+	return hiddenVec;
+}
+
+std::wstring removeDefaultStyleName(const wchar_t* key) {
+	const std::wstring keyName = key;
+	if (keyName.find(L"Default$") == 0)
+		return keyName.substr(8);
+	else
+		return keyName;
+}
+
 /**
  * Helper function to convert a Python dictionary of "<key>:<value>" into a
  * prt::AttributeMap

--- a/src/client/utils.cpp
+++ b/src/client/utils.cpp
@@ -60,6 +60,8 @@ namespace py = pybind11;
 
 namespace pcu {
 
+constexpr const wchar_t* CGA_STYLE_DEFAULT = L"Default$";
+
 bool getResolveMap(const std::filesystem::path& rulePackagePath, ResolveMapPtr* resolveMap) {
 	if (std::filesystem::exists(rulePackagePath)) {
 		LOG_INF << "using rule package " << rulePackagePath << std::endl;
@@ -133,8 +135,8 @@ std::vector<std::wstring> getHiddenAttributes(const RuleFileInfoUPtr& ruleFileIn
 
 std::wstring removeDefaultStyleName(const wchar_t* key) {
 	const std::wstring keyName = key;
-	if (keyName.find(L"Default$") == 0)
-		return keyName.substr(8);
+	if (keyName.find(CGA_STYLE_DEFAULT) == 0)
+		return keyName.substr(wcslen(CGA_STYLE_DEFAULT));
 	else
 		return keyName;
 }

--- a/src/client/utils.cpp
+++ b/src/client/utils.cpp
@@ -119,14 +119,14 @@ std::wstring detectStartRule(const RuleFileInfoUPtr& ruleFileInfo) {
 	return {};
 }
 
-std::vector<std::wstring> getHiddenAttributes(const RuleFileInfoUPtr& ruleFileInfo) {
-	std::vector<std::wstring> hiddenVec;
+std::unordered_set<std::wstring> getHiddenAttributes(const RuleFileInfoUPtr& ruleFileInfo) {
+	std::unordered_set<std::wstring> hiddenVec;
 
 	for (size_t ai = 0, numAttrs = ruleFileInfo->getNumAttributes(); ai < numAttrs; ai++) {
 		const auto attr = ruleFileInfo->getAttribute(ai);
 		for (size_t k = 0, numAnns = attr->getNumAnnotations(); k < numAnns; k++) {
 			if (std::wcscmp(attr->getAnnotation(k)->getName(), L"@Hidden") == 0)
-				hiddenVec.push_back(attr->getName());
+				hiddenVec.insert(attr->getName());
 		}
 	}
 

--- a/src/client/utils.h
+++ b/src/client/utils.h
@@ -40,7 +40,7 @@ std::filesystem::path getModuleDirectory();
 bool getResolveMap(const std::filesystem::path& rulePackagePath, ResolveMapPtr* resolveMap);
 std::wstring getRuleFileEntry(const prt::ResolveMap* resolveMap);
 std::wstring detectStartRule(const RuleFileInfoUPtr& ruleFileInfo);
-std::vector<std::wstring> getHiddenAttributes(const RuleFileInfoUPtr& ruleFileInfo);
+std::unordered_set<std::wstring> getHiddenAttributes(const RuleFileInfoUPtr& ruleFileInfo);
 std::wstring removeDefaultStyleName(const wchar_t* key);
 
 AttributeMapPtr createAttributeMapFromPythonDict(const py::dict& args, prt::AttributeMapBuilder& bld);

--- a/src/client/utils.h
+++ b/src/client/utils.h
@@ -40,7 +40,6 @@ std::filesystem::path getModuleDirectory();
 bool getResolveMap(const std::filesystem::path& rulePackagePath, ResolveMapPtr* resolveMap);
 std::wstring getRuleFileEntry(const prt::ResolveMap* resolveMap);
 std::wstring detectStartRule(const RuleFileInfoUPtr& ruleFileInfo);
-std::wstring removeStylePrefix(const std::wstring& fullName);
 
 AttributeMapPtr createAttributeMapFromPythonDict(const py::dict& args, prt::AttributeMapBuilder& bld);
 AttributeMapPtr createValidatedOptions(const std::wstring& encID, const AttributeMapPtr& unvalidatedOptions);

--- a/src/client/utils.h
+++ b/src/client/utils.h
@@ -40,6 +40,8 @@ std::filesystem::path getModuleDirectory();
 bool getResolveMap(const std::filesystem::path& rulePackagePath, ResolveMapPtr* resolveMap);
 std::wstring getRuleFileEntry(const prt::ResolveMap* resolveMap);
 std::wstring detectStartRule(const RuleFileInfoUPtr& ruleFileInfo);
+std::vector<std::wstring> getHiddenAttributes(const RuleFileInfoUPtr& ruleFileInfo);
+std::wstring removeDefaultStyleName(const wchar_t* key);
 
 AttributeMapPtr createAttributeMapFromPythonDict(const py::dict& args, prt::AttributeMapBuilder& bld);
 AttributeMapPtr createValidatedOptions(const std::wstring& encID, const AttributeMapPtr& unvalidatedOptions);

--- a/src/codec/encoder/PyEncoder.cpp
+++ b/src/codec/encoder/PyEncoder.cpp
@@ -136,9 +136,8 @@ void PyEncoder::encode(prtx::GenerateContext& context, size_t initialShapeIndex)
 		try {
 			const prtx::LeafIteratorPtr li = prtx::LeafIterator::create(context, initialShapeIndex);
 
-			for (prtx::ShapePtr shape = li->getNext(); shape.get() != nullptr; shape = li->getNext()) {
+			for (prtx::ShapePtr shape = li->getNext(); shape.get() != nullptr; shape = li->getNext())
 				mEncodePreparator->add(context.getCache(), shape, is->getAttributeMap());
-			}
 		}
 		catch (...) {
 			mEncodePreparator->add(context.getCache(), *is, initialShapeIndex);

--- a/tests/pyGeometry_test.py
+++ b/tests/pyGeometry_test.py
@@ -190,7 +190,7 @@ class GeometryTest(unittest.TestCase):
             asset_file('building_parcel.obj'))
         m = pyprt.ModelGenerator([shape_geo_from_obj, shape_geo_from_obj])
         model = m.generate_model([attrs, attrs2], rpk, 'com.esri.pyprt.PyEncoder', {})
-        self.assertDictEqual(model[0].get_attributes_values(),
+        self.assertDictEqual(model[0].get_attributes(),
                 {'maxBuildingHeight': 35.0, 'OBJECTID': 0.0, 'minBuildingHeight': 10.0, 'buildingColor': '#FF00FF', 'text': 'salut'})
-        self.assertDictEqual(model[1].get_attributes_values(),
+        self.assertDictEqual(model[1].get_attributes(),
                 {'OBJECTID': 0.0, 'minBuildingHeight': 10.0, 'buildingColor': '#FF00FF', 'text': 'salut', 'maxBuildingHeight': 30.0})

--- a/tests/pyGeometry_test.py
+++ b/tests/pyGeometry_test.py
@@ -181,3 +181,16 @@ class GeometryTest(unittest.TestCase):
             'emitReport': True, 'emitGeometry': False})
 
         self.assertEqual(len(model[0].get_cga_errors()), 1)
+
+    def test_attributesvalue_fct(self):
+        rpk = asset_file('extrusion_rule.rpk')
+        attrs = {'maxBuildingHeight':35.0}
+        attrs2 = {}
+        shape_geo_from_obj = pyprt.InitialShape(
+            asset_file('building_parcel.obj'))
+        m = pyprt.ModelGenerator([shape_geo_from_obj, shape_geo_from_obj])
+        model = m.generate_model([attrs, attrs2], rpk, 'com.esri.pyprt.PyEncoder', {})
+        self.assertDictEqual(model[0].get_attributes_values(),
+                {'maxBuildingHeight': 35.0, 'OBJECTID': 0.0, 'minBuildingHeight': 10.0, 'buildingColor': '#FF00FF', 'text': 'salut'})
+        self.assertDictEqual(model[1].get_attributes_values(),
+                {'OBJECTID': 0.0, 'minBuildingHeight': 10.0, 'buildingColor': '#FF00FF', 'text': 'salut', 'maxBuildingHeight': 30.0})


### PR DESCRIPTION
Until now, the only way for the user to know the rule attributes values used to generate a specific model was to modify the CGA rule for it to report the values.
With this new "get_attributes_values()" function, the user can access the rule attributes values used after a model generation.