### PR TITLE
Add triangulate flag to PyEncoder options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ repo_path = os.path.dirname(os.path.realpath(__file__))
 rpk = os.path.join(repo_path, 'tests/data/extrusion_rule.rpk')
 shape_attributes = {'shapeName': 'myShape', 'seed': 555}
 encoder = 'com.esri.pyprt.PyEncoder'
-encoder_options = {'emitReport': True, 'emitGeometry': True}
+encoder_options = {'emitReport': True, 'emitGeometry': True, 'triangulate': False}
 
 # Generate the model
 generated_models = model_generator.generate_model([shape_attributes], rpk, encoder, encoder_options)

--- a/example.py
+++ b/example.py
@@ -29,7 +29,7 @@ repo_path = os.path.dirname(os.path.realpath(__file__))
 rpk = os.path.join(repo_path, 'tests/data/extrusion_rule.rpk')
 shape_attributes = {'shapeName': 'myShape', 'seed': 555}
 encoder = 'com.esri.pyprt.PyEncoder'
-encoder_options = {'emitReport': True, 'emitGeometry': True}
+encoder_options = {'emitReport': True, 'emitGeometry': True, 'triangulate': False}
 
 # Generate the model
 generated_models = model_generator.generate_model([shape_attributes], rpk, encoder, encoder_options)

--- a/src/client/doc.h
+++ b/src/client/doc.h
@@ -174,7 +174,7 @@ constexpr const char* MgGen = R"mydelimiter(
         the shape attribute dictionary will contain the CGA input attributes specific to the CGA file you are using (use the
         ``get_rpk_attributes_info`` function to know these input attributes). Concerning the encoder, you can use the
         ``'com.esri.pyprt.PyEncoder'`` or any other geometry encoder. The PyEncoder has two options:
-        ``'emitGeometry'`` and ``'emitReport'`` whose value is a boolean. The complete list of the other geometry
+        ``'emitGeometry'``, ``'emitReport'`` and ``'triangulate'`` whose value is a boolean. The complete list of the other geometry
         encoders can be found `here <https://esri.github.io/esri-cityengine-sdk/html/esri_prt_codecs.html>`__. In
         case you are using another geometry encoder than the PyEncoder, you can add an ``'outputPath'`` entry to
         the shape attribute dictionary to specify where the generated 3D geometry will be outputted. In this case,

--- a/src/codec/encoder/PyEncoder.cpp
+++ b/src/codec/encoder/PyEncoder.cpp
@@ -43,10 +43,11 @@ namespace {
 const wchar_t* EO_BASE_NAME = L"baseName";
 const wchar_t* EO_ERROR_FALLBACK = L"errorFallback";
 const std::wstring ENCFILE_EXT = L".txt";
+const wchar_t* EO_TRIANGULATE = L"triangulate";
 const wchar_t* EO_EMIT_REPORT = L"emitReport";
 const wchar_t* EO_EMIT_GEOMETRY = L"emitGeometry";
 
-const prtx::EncodePreparator::PreparationFlags ENC_PREP_FLAGS =
+prtx::EncodePreparator::PreparationFlags ENC_PREP_FLAGS =
         prtx::EncodePreparator::PreparationFlags()
                 .instancing(false)
                 .triangulate(false)
@@ -86,6 +87,10 @@ void PyEncoder::encode(prtx::GenerateContext& context, size_t initialShapeIndex)
 	auto* cb = getPyCallbacks(getCallbacks());
 	if (cb == nullptr)
 		throw prtx::StatusException(prt::STATUS_ILLEGAL_CALLBACK_OBJECT);
+
+	if (getOptions()->getBool(EO_TRIANGULATE)) {
+		ENC_PREP_FLAGS.triangulate(true);
+	}
 
 	if (getOptions()->getBool(EO_EMIT_REPORT)) {
 		prtx::ReportsAccumulatorPtr reportsAccumulator{prtx::SummarizingReportsAccumulator::create()};
@@ -198,6 +203,7 @@ PyEncoderFactory* PyEncoderFactory::createInstance() {
 	prtx::PRTUtils::AttributeMapBuilderPtr amb(prt::AttributeMapBuilder::create());
 	amb->setString(EO_BASE_NAME, L"enc_default_name"); // required by CityEngine
 	amb->setBool(EO_ERROR_FALLBACK, prtx::PRTX_TRUE);  // required by CityEngine
+	amb->setBool(EO_TRIANGULATE, prtx::PRTX_FALSE);
 	amb->setBool(EO_EMIT_REPORT, prtx::PRTX_TRUE);
 	amb->setBool(EO_EMIT_GEOMETRY, prtx::PRTX_TRUE);
 	encoderInfoBuilder.setDefaultOptions(amb->createAttributeMap());


### PR DESCRIPTION
This PR adds a `triangulate` option to the PyEncoder. See issue:  #125 

Let me know if this approach is okay, or if it should be done differently.
I might also need some help with the tests, I'm not sure if I can run them on my Mac.
I've been building directly inside a linux docker container.

And if you have any guidelines for contributing to this repo, please let me know ;)