### PR TITLE
Use psl.runContainerBuild when building container images

### DIFF
--- a/envs/Jenkinsfile
+++ b/envs/Jenkinsfile
@@ -146,9 +146,11 @@ def taskBuildDockerImage(cfg) {
 
 	dir(path: SOURCE) {
 		docker.withRegistry("https://${DOCKER_REGISTRY}", 'jenkins-pyprt-dreg-robot') {
-			def dockerImage = docker.build(image, "-m 8GB --rm -f ${dockerFile} ${buildArgs} ${labelArgs} ${targetArgs} .")
-			dockerImage.push(tag)
-			psl.runCmd("docker image prune -a -f --filter label=${buildLabel}")
+			psl.runContainerBuild() {
+				def dockerImage = docker.build(image, "-m 8GB --rm -f ${dockerFile} ${buildArgs} ${labelArgs} ${targetArgs} .")
+				dockerImage.push(tag)
+				psl.runCmd("docker image prune -a -f --filter label=${buildLabel}")
+			}
 		}
 	}
 }


### PR DESCRIPTION
This should ensure that concurrent job execution does not interfere with container builds. Note too that this is only required on Windows since Docker on Windows does not support BuildKit yet.